### PR TITLE
Handle inconsistent casing of exercise.type while filtering data

### DIFF
--- a/app/exercises.tsx
+++ b/app/exercises.tsx
@@ -40,7 +40,11 @@ export default function ExercisesScreen() {
 
   const getFilteredExercises = () => {
     if (selectedType === "all") return exercises;
-    return exercises.filter((exercise) => exercise.type === selectedType);
+    return exercises.filter(
+      (exercise) =>
+        exercise.type === selectedType ||
+        exercise.type === selectedType.toLowerCase()
+    );
   };
 
   const handleFilterChange = (value: string) => {


### PR DESCRIPTION
Improvements to filtering logic:

* [`app/exercises.tsx`](diffhunk://#diff-0640cbf1143ad62c8054b66881a5174acee702e6c7c053decc578a68350c1472L43-R47): Modified the `getFilteredExercises` function to include a case-insensitive comparison for the `selectedType` filter. This ensures that exercises are filtered correctly even if the `selectedType` is in a different case.